### PR TITLE
Fix CI install commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: lts/*
           cache: npm
       - name: Install commitlint
-        run: npm install -D @commitlint/cli @commitlint/config-conventional
+        run: npm ci
       - name: Print versions
         run: |
           git --version
@@ -46,7 +46,7 @@ jobs:
           node-version: lts/*
           cache: npm
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Run tests
         run: npm test
 


### PR DESCRIPTION
## Summary
- use `npm ci` for commitlint setup
- use `npm ci` for tests job

## Testing
- `npm test`
- `npx tsc --noEmit` *(fails: no project configured)*

------
https://chatgpt.com/codex/tasks/task_e_68613f5faac48327b65f4f9e3101f62b