### PR TITLE
fix: build artifact before release upload

### DIFF
--- a/.github/workflows/release-please-main.yml
+++ b/.github/workflows/release-please-main.yml
@@ -14,8 +14,13 @@ jobs:
         id: release
         with:
           release-type: node
+      - name: Build Release Artifact
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          mkdir -p artifact
+          npm pack --pack-destination artifact
       - name: Upload Release Artifact
         if: ${{ steps.release.outputs.release_created }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ steps.release.outputs.tag_name }} ./artifact/some-build-artifact.zip
+        run: gh release upload ${{ steps.release.outputs.tag_name }} artifact/*.tgz


### PR DESCRIPTION
## Summary
- update GitHub workflow so the release artifact is generated with `npm pack` before uploading

## Testing
- `npm ci`
- `npx tsc -p tsconfig.app.json --noEmit`
- `npx tsc -p tsconfig.package.json --noEmit`
- `npx tsc -p tsconfig.client.json --noEmit`
- `npm test`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_686155adb29883278527862663d7c8ee