### PR TITLE
Add release workflow permissions

### DIFF
--- a/.github/workflows/release-please-main.yml
+++ b/.github/workflows/release-please-main.yml
@@ -8,6 +8,9 @@ name: release-please-main
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: googleapis/release-please-action@v4


### PR DESCRIPTION
## Summary
- allow `contents` and `pull-requests` writes in release workflow

## Testing
- `npm ci`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68615cae9628832787015c7ae100e942