### PR TITLE
Add issue templates and CI failure workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: "Bug ou sugestão de funcionalidade"
+about: "Relate um bug ou sugira uma nova feature"
+title: "[Bug/Feature]: "
+labels: []
+assignees: []
+---
+
+**Descreva o problema ou sugestão**
+Uma descrição clara do que está acontecendo ou do que você gostaria que acontecesse.
+
+**Passos para reproduzir (se for um bug)**
+1. ...
+2. ...
+3. ...
+
+**Comportamento esperado**
+Descreva o comportamento esperado.
+
+**Informações adicionais**
+Adicione quaisquer outras informações relevantes, logs ou capturas de tela.

--- a/.github/ISSUE_TEMPLATE/ci_failure.md
+++ b/.github/ISSUE_TEMPLATE/ci_failure.md
@@ -1,0 +1,5 @@
+Falha detectada na execução do workflow CI.
+
+Consulte os logs do workflow em: ${{ github.event.workflow_run.html_url }}
+
+Favor investigar o problema.

--- a/.github/workflows/ci-error-issue.yml
+++ b/.github/workflows/ci-error-issue.yml
@@ -1,0 +1,23 @@
+name: Abrir issue em falha de CI
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  abrir_issue:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Criar issue
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: "Falha na CI em ${{ github.event.workflow_run.head_branch }}"
+          content-file: .github/ISSUE_TEMPLATE/ci_failure.md
+          labels: ci,bug


### PR DESCRIPTION
## Summary
- add bug/feature report template
- add CI failure issue template and workflow

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_686161e2e49c8327839df37a7ff54b3c