### PR TITLE
Configure CODEOWNERS and workflow tokens

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @JefteCosta @jefte-bot-pr @jefte-bot-issue

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -15,5 +15,5 @@ jobs:
         uses: pozil/auto-assign-issue@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: JefteCosta
+          assignees: JefteCosta,jefte-bot-pr
           numOfAssignee: 1

--- a/.github/workflows/ci-error-issue.yml
+++ b/.github/workflows/ci-error-issue.yml
@@ -21,3 +21,4 @@ jobs:
           title: "Falha na CI em ${{ github.event.workflow_run.head_branch }}"
           content-filepath: .github/ISSUE_TEMPLATE/ci_failure.md
           labels: ci,bug
+          github-token: ${{ secrets.JEFT_ISSUE_TOKEN }}

--- a/.github/workflows/release-please-main.yml
+++ b/.github/workflows/release-please-main.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Upload Release Artifact
         if: ${{ steps.release.outputs.release_created }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: gh release upload ${{ steps.release.outputs.tag_name }} artifact/*.tgz


### PR DESCRIPTION
## Summary
- add CODEOWNERS file listing the bots
- update release workflow to use `RELEASE_PLEASE_TOKEN`
- allow CI error workflow to authenticate via `JEFT_ISSUE_TOKEN`
- auto-assign PRs to `jefte-bot-pr`

## Testing
- `npm ci`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6862825a47088327977f94af553b9087