### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contribuindo
+
+Obrigado por contribuir com **@arapucajs/tsconfig**!
+
+Este projeto utiliza [Release Please](https://github.com/google-github-actions/release-please) para gerar changelogs e versões automaticamente. Para que isso funcione, siga o padrão **Conventional Commits** ao escrever suas mensagens de commit.
+
+Exemplos de prefixos aceitos:
+
+- `feat`: novo recurso ou funcionalidade
+- `fix`: correção de bug
+- `docs`: apenas mudanças na documentação
+- `chore`: tarefas de manutenção
+
+Commits fora desse formato podem falhar na validação do `commitlint` e não serão usados pelo Release Please ao calcular a próxima versão.
+
+1. Forke este repositório e crie uma branch para sua mudança.
+2. Rode `bun test` antes de enviar o Pull Request.
+3. Abra seu PR seguindo as instruções acima.
+
+Obrigado!

--- a/README.md
+++ b/README.md
@@ -197,3 +197,8 @@ Após instalar, use um dos arquivos de configuração base.
 ```
 
 
+
+## Como contribuir
+
+Contribuições são bem-vindas! Consulte o [CONTRIBUTING.md](./CONTRIBUTING.md) para seguir o padrão de **Conventional Commits**. Dessa forma o Release Please poderá gerar versões automaticamente.
+


### PR DESCRIPTION
## Summary
- document how to contribute using Conventional Commits
- link `CONTRIBUTING.md` from `README`

## Testing
- `npm ci`
- `npx tsc --noEmit -p tsconfig.package.json`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68649c331fc883278940f727d9dab210