### PR TITLE
Fix trailing comma in client tsconfig

### DIFF
--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["DOM", "ESNext","DOM.Iterable","ES2022"],
+    "lib": ["DOM", "ESNext","DOM.Iterable","ES2022"]
   }
 }


### PR DESCRIPTION
## Summary
- remove trailing comma from `lib` array in `tsconfig.client.json`

## Testing
- `npm ci`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6864a157c28483278464de0e12798bc7