### PR TITLE
Fix Bun typings placement

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,10 +59,6 @@
     "@types/bun": "^1.2.17",
     "bun-types": "^1.2.17"
   },
-  "dependencies": {
-    "@types/bun": "^1.2.17",
-    "bun-types": "^1.2.17"
-  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"


### PR DESCRIPTION
## Summary
- remove duplicate `bun-types` deps
- keep bun typings only as peer deps

## Testing
- `npm ci`
- `tsc --noEmit` *(shows help output)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864a429f91883279692765875ae07da